### PR TITLE
53 screening info

### DIFF
--- a/app/views/screenings/show.html.erb
+++ b/app/views/screenings/show.html.erb
@@ -1,3 +1,10 @@
 <%= "Showing at #{@cinema.name}" %><br>
+<%= "#{@cinema.phone}" %>
+<%= "#{@cinema.address.split(",")[0]}" %>
+<%= "#{@cinema.address.split(",")[1]}" %>
+<%= "#{@cinema.address.split(",")[2]}" %>
 <%= link_to "Website: #{@cinema.name} Showtimes", @cinema.website %><br>
-<%= @screening.screen_date %><br>
+<%= @screening.screen_date.strftime('%A') %>
+<%= @screening.screen_date.day %>
+<%= @screening.screen_date.strftime('%B') %>
+<%= @screening.screen_date.year %>

--- a/app/views/screenings/show.html.erb
+++ b/app/views/screenings/show.html.erb
@@ -1,10 +1,16 @@
-<%= "Showing at #{@cinema.name}" %><br>
-<%= "#{@cinema.phone}" %>
-<%= "#{@cinema.address.split(",")[0]}" %>
-<%= "#{@cinema.address.split(",")[1]}" %>
-<%= "#{@cinema.address.split(",")[2]}" %>
-<%= link_to "Website: #{@cinema.name} Showtimes", @cinema.website %><br>
-<%= @screening.screen_date.strftime('%A') %>
-<%= @screening.screen_date.day %>
-<%= @screening.screen_date.strftime('%B') %>
-<%= @screening.screen_date.year %>
+<div class="row">
+  <div class="col-md-4"></div>
+  <div class="col-md-4">
+    <h2><%="#{@cinema.name}"%></h2>
+
+      <h3><%= @screening.screen_time.strftime('%H:%M') %></h3>
+      <h4><%= @screening.screen_date.strftime('%A %e %B %Y') %></h4>
+      <%= "#{@cinema.address.split(",")[0]}" %><br />
+      <%= "#{@cinema.address.split(",")[1]}" %><br />
+      <%= "#{@cinema.postcode}" %><br />
+      <%= "#{@cinema.phone}" %><br />
+      Website: <%= link_to "#{@cinema.name} Showtimes", @cinema.website %><br>
+
+  </div>
+  <div class="col-md-4"></div>
+</div>

--- a/spec/features/screenings_feature_spec.rb
+++ b/spec/features/screenings_feature_spec.rb
@@ -23,7 +23,7 @@ feature 'screenings' do
   context "A user wants to know about upcoming screenings" do
     scenario "User's are notified of an upcoming screening for a film on their Cinefile" do
       film = Film.create(title: 'Brazil', tmdb_id: '68', poster_path: '/pVlZBKp8v3Jzd0ahPmrBGlbeQ2s.jpg')
-      Screening.create(film_id: film.id, screen_date: Time.now + 86400)
+      Screening.create(film_id: film.id, screen_date: Time.now + 86400, screen_time: "22:00")
       sign_up
       click_link_cinefile
       add_film
@@ -35,7 +35,7 @@ feature 'screenings' do
       film = Film.create(title: 'Brazil', tmdb_id: '68', poster_path: '/pVlZBKp8v3Jzd0ahPmrBGlbeQ2s.jpg')
       cinema = Cinema.create(name: 'Curzon Victoria', phone: 03305001331, address: '58 Victoria Street, London, SW1E 6QW',
                             website: 'http://www.curzoncinemas.com/victoria/now-showing')
-      Screening.create(film_id: film.id, screen_date: Time.now + 86400, cinema_id: cinema.id)
+      Screening.create(film_id: film.id, screen_date: Time.now + 86400, screen_time: "22:00", cinema_id: cinema.id)
       sign_up
       click_link_cinefile
       add_film
@@ -47,7 +47,7 @@ feature 'screenings' do
       film = Film.create(title: 'Hell or High Water', tmdb_id: '338766', poster_path: '/5GbRKOQSY08U3SQXXcQAKEnL2rE.jpg')
       cinema = Cinema.create(name: 'Curzon Victoria', phone: 03305001331, address: '58 Victoria Street, London, SW1E 6QW',
                             website: 'http://www.curzoncinemas.com/victoria/now-showing')
-      Screening.create(film_id: film.id, screen_date: Time.now + 86400, cinema_id: cinema.id)
+      Screening.create(film_id: film.id, screen_date: Time.now + 86400, screen_time: "22:00", cinema_id: cinema.id)
       sign_up
       click_link_cinefile
       add_film(title: 'Hell or High Water')
@@ -58,9 +58,9 @@ feature 'screenings' do
 
     scenario "The address and phone number of the cinema is displayed for each screening " do
       film = Film.create(title: 'Hell or High Water', tmdb_id: '338766', poster_path: '/5GbRKOQSY08U3SQXXcQAKEnL2rE.jpg')
-      cinema = Cinema.create(name: 'Curzon Victoria', phone: 03305001331, address: '58 Victoria Street, London, SW1E 6QW',
-                            website: 'http://www.curzoncinemas.com/victoria/now-showing')
-      Screening.create(film_id: film.id, screen_date: Time.now + 86400, cinema_id: cinema.id)
+      cinema = Cinema.create(name: 'Curzon Victoria', phone: 03305001331, address: '58 Victoria Street, London',
+                            postcode: 'SW1E 6QW', website: 'http://www.curzoncinemas.com/victoria/now-showing')
+      Screening.create(film_id: film.id, screen_date: Time.now + 86400, screen_time: "22:00", cinema_id: cinema.id)
       sign_up
       click_link_cinefile
       add_film(title: 'Hell or High Water')
@@ -89,7 +89,7 @@ feature 'screenings' do
   context "A user wants to know about upcoming screenings" do
     scenario "User's are notified of an upcoming screening for a film on their Cinefile" do
       film = Film.create(title: 'Brazil', tmdb_id: '68', poster_path: '/pVlZBKp8v3Jzd0ahPmrBGlbeQ2s.jpg')
-      screening = Screening.create(film_id: film.id, screen_date: Time.now + 86400)
+      screening = Screening.create(film_id: film.id, screen_time: "22:00", screen_date: Time.now + 86400)
       sign_up
       click_link_cinefile
       add_film

--- a/spec/features/screenings_feature_spec.rb
+++ b/spec/features/screenings_feature_spec.rb
@@ -40,7 +40,7 @@ feature 'screenings' do
       click_link_cinefile
       add_film
       click_button "Screening Info"
-      expect(page).to have_content("Showing at Curzon Victoria")
+      expect(page).to have_content("Curzon Victoria")
     end
 
     scenario "A user can access a link to the cinema's website" do
@@ -52,7 +52,7 @@ feature 'screenings' do
       click_link_cinefile
       add_film(title: 'Hell or High Water')
       click_button "Screening Info"
-      expect(page).to have_content("Showing at Curzon Victoria")
+      expect(page).to have_content("Curzon Victoria")
       expect(page).to have_content("Website: Curzon Victoria Showtimes")
     end
 

--- a/spec/features/screenings_feature_spec.rb
+++ b/spec/features/screenings_feature_spec.rb
@@ -33,18 +33,20 @@ feature 'screenings' do
   context "Viewing info on specific screenings" do
     scenario "A user can click through for info on a screening" do
       film = Film.create(title: 'Brazil', tmdb_id: '68', poster_path: '/pVlZBKp8v3Jzd0ahPmrBGlbeQ2s.jpg')
-      cinema = Cinema.create(name: 'The Waterfront')
+      cinema = Cinema.create(name: 'Curzon Victoria', phone: 03305001331, address: '58 Victoria Street, London, SW1E 6QW',
+                            website: 'http://www.curzoncinemas.com/victoria/now-showing')
       Screening.create(film_id: film.id, screen_date: Time.now + 86400, cinema_id: cinema.id)
       sign_up
       click_link_cinefile
       add_film
       click_button "Screening Info"
-      expect(page).to have_content("Showing at The Waterfront")
+      expect(page).to have_content("Showing at Curzon Victoria")
     end
 
     scenario "A user can access a link to the cinema's website" do
       film = Film.create(title: 'Hell or High Water', tmdb_id: '338766', poster_path: '/5GbRKOQSY08U3SQXXcQAKEnL2rE.jpg')
-      cinema = Cinema.create(name: 'Curzon Victoria', website: 'http://www.curzoncinemas.com/victoria/now-showing')
+      cinema = Cinema.create(name: 'Curzon Victoria', phone: 03305001331, address: '58 Victoria Street, London, SW1E 6QW',
+                            website: 'http://www.curzoncinemas.com/victoria/now-showing')
       Screening.create(film_id: film.id, screen_date: Time.now + 86400, cinema_id: cinema.id)
       sign_up
       click_link_cinefile
@@ -52,6 +54,20 @@ feature 'screenings' do
       click_button "Screening Info"
       expect(page).to have_content("Showing at Curzon Victoria")
       expect(page).to have_content("Website: Curzon Victoria Showtimes")
+    end
+
+    scenario "The address and phone number of the cinema is displayed for each screening " do
+      film = Film.create(title: 'Hell or High Water', tmdb_id: '338766', poster_path: '/5GbRKOQSY08U3SQXXcQAKEnL2rE.jpg')
+      cinema = Cinema.create(name: 'Curzon Victoria', phone: 03305001331, address: '58 Victoria Street, London, SW1E 6QW',
+                            website: 'http://www.curzoncinemas.com/victoria/now-showing')
+      Screening.create(film_id: film.id, screen_date: Time.now + 86400, cinema_id: cinema.id)
+      sign_up
+      click_link_cinefile
+      add_film(title: 'Hell or High Water')
+      click_button "Screening Info"
+      expect(page).to have_content(03305001331)
+      expect(page).to have_content "58 Victoria Street"
+      expect(page).to have_content "SW1E 6QW"
     end
   end
 


### PR DESCRIPTION
Displays date and time for screenings as well as cinema info in a fairly user friendly way.
We're still doing this with a separate button to each screening, which is not good. NEXT: one button which links to all screenings for said film.
